### PR TITLE
Feat: Unify build process, separate articles, and fix bugs

### DIFF
--- a/scripts/update_tracker.py
+++ b/scripts/update_tracker.py
@@ -8,15 +8,64 @@ def latest_per_tool(items):
             by[k]=it
     return by
 def main():
-    ap = argparse.ArgumentParser(); ap.add_argument("--tracker", required=True); ap.add_argument("--log", required=True); ap.add_argument("--out", required=True); args = ap.parse_args()
-    log = json.load(open(args.log,"r",encoding="utf-8")); latest = latest_per_tool(log.get("items",[]))
-    with open(args.tracker,"r",encoding="utf-8") as f:
-        rdr = csv.DictReader(f); rows=[]; fields=rdr.fieldnames
-        if "Status" not in fields: fields = list(fields) + ["Status"]
-        for r in rdr:
-            it = latest.get(r["Tool"])
-            if it: r["Status"] = f'{it["severity"]}: {it["headline"]} ({it["date"]})'
-            rows.append(r)
-    with open(args.out,"w",encoding="utf-8",newline="") as f:
-        w=csv.DictWriter(f, fieldnames=fields); w.writeheader(); w.writerows(rows)
-if __name__=="__main__": main()
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--tracker", required=True, help="Input CSV file for tool tracking")
+    ap.add_argument("--log", required=True, help="Input JSON file with news items")
+    ap.add_argument("--out", required=True, help="Output CSV file")
+    args = ap.parse_args()
+
+    # Load the latest news items
+    try:
+        with open(args.log, "r", encoding="utf-8") as f:
+            log = json.load(f)
+        latest = latest_per_tool(log.get("items", []))
+    except FileNotFoundError:
+        print(f"Log file not found at {args.log}. No statuses will be updated.")
+        latest = {}
+    except json.JSONDecodeError:
+        print(f"Error decoding JSON from {args.log}. No statuses will be updated.")
+        latest = {}
+
+    # Read the tracker CSV, update statuses, and clean the data
+    try:
+        with open(args.tracker, "r", encoding="utf-8") as f:
+            reader = csv.DictReader(f)
+
+            # Sanitize fieldnames to remove any None keys from blank columns
+            original_fields = reader.fieldnames or []
+            clean_fields = [field for field in original_fields if field is not None]
+
+            if "Status" not in clean_fields:
+                clean_fields.append("Status")
+
+            updated_rows = []
+            for row in reader:
+                # Create a new row dictionary, filtering out the None key if it exists
+                clean_row = {k: v for k, v in row.items() if k is not None}
+
+                tool_name = clean_row.get("Tool")
+                if tool_name:
+                    latest_item = latest.get(tool_name)
+                    if latest_item:
+                        clean_row["Status"] = f'{latest_item.get("severity", "Minor")}: {latest_item.get("headline", "")} ({latest_item.get("date", "")})'
+
+                updated_rows.append(clean_row)
+    except FileNotFoundError:
+        print(f"Tracker file not found at {args.tracker}. Cannot proceed.")
+        return
+    except Exception as e:
+        print(f"An unexpected error occurred while reading {args.tracker}: {e}")
+        return
+
+    # Write the cleaned and updated data back to the output file
+    try:
+        with open(args.out, "w", encoding="utf-8", newline="") as f:
+            writer = csv.DictWriter(f, fieldnames=clean_fields)
+            writer.writeheader()
+            writer.writerows(updated_rows)
+        print(f"Successfully updated tracker status and wrote to {args.out}.")
+    except Exception as e:
+        print(f"An unexpected error occurred while writing to {args.out}: {e}")
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
This commit provides a comprehensive refactoring of the entire site generation process to fix build failures and improve maintainability.

- Consolidates the two previous CI workflows into a single, robust `main.yml`.
- Implements a new data pipeline to categorize discoveries into "Tools" (`tools.csv`) and "Articles" (`articles.csv`).
- Adds a new "Articles" page and a script to prune old articles.
- Refactors all build scripts to be self-contained and consistent.
- Fixes a bug in `update_tracker.py` that caused errors with malformed CSVs.
- Adds comprehensive documentation for the new architecture.